### PR TITLE
Create a new role for kittens to learn the system

### DIFF
--- a/laravel/app/Console/Commands/Notifications/Send.php
+++ b/laravel/app/Console/Commands/Notifications/Send.php
@@ -122,7 +122,7 @@ class Send extends Command
         }
 
         // Send daily digest email with different templates based on the user it's being sent to
-        if(in_array($user->role, ['judge', 'observer']))
+        if(in_array($user->role, ['judge', 'kitten', 'observer']))
         {
             echo "Sending daily digest email to judge: {$user->email}\n";
             Mail::send("emails/judge-daily-digest", compact('applications'), function ($message) use ($user)

--- a/laravel/app/Http/Controllers/ApplicationController.php
+++ b/laravel/app/Http/Controllers/ApplicationController.php
@@ -34,7 +34,7 @@ class ApplicationController extends Controller
             {
                 $applications = Application::orderBy('updated_at', 'asc')->get();
             }
-            elseif(in_array($this->auth->user()->role, ['judge', 'observer']))
+            elseif(in_array($this->auth->user()->role, ['judge', 'kitten', 'observer']))
             {
                 $applications = Application::whereIn('status', ['submitted', 'review', 'accepted', 'rejected'])->orderBy('updated_at', 'asc')->get();
             }
@@ -359,13 +359,20 @@ class ApplicationController extends Controller
             $judged->application_id = $application->id;
             $judged->user_id = Auth::user()->id;
 
-            if($request->exists('abstain'))
+            if(Auth::user()->role == 'kitten')
             {
                 $judged->status = 'abstain';
             }
             else
             {
-                $judged->status = 'judged';
+                if($request->exists('abstain'))
+                {
+                    $judged->status = 'abstain';
+                }
+                else
+                {
+                    $judged->status = 'judged';
+                }
             }
 
             $judged->save();

--- a/laravel/app/Http/Controllers/PageController.php
+++ b/laravel/app/Http/Controllers/PageController.php
@@ -25,7 +25,7 @@ class PageController extends Controller
 
         if($this->auth->check())
         {
-            if(in_array($this->auth->user()->role, ['judge', 'observer']))
+            if(in_array($this->auth->user()->role, ['judge', 'kitten', 'observer']))
             {
                 // Get all applications where the application is submitted and the judge has not submitted a score(judged).
                 // TODO: There should be a way to make this work with a single eloquent db access via a left join

--- a/laravel/app/Http/Controllers/UserController.php
+++ b/laravel/app/Http/Controllers/UserController.php
@@ -79,7 +79,7 @@ class UserController extends Controller
     {
         if($this->auth->check())
         {
-            if(in_array($this->auth->user()->role, ['admin', 'judge', 'observer']))
+            if(in_array($this->auth->user()->role, ['admin', 'judge', 'kitten', 'observer']))
             {
                 if($request->query('search'))
                 {
@@ -103,7 +103,7 @@ class UserController extends Controller
         }
     return redirect('');
     }
-    
+
 
     public function viewUser(User $user, Request $request)
     {
@@ -121,6 +121,7 @@ class UserController extends Controller
 
         // Remove empty inputs
         $input = array_filter($input);
+
 
         if($input['type'] == 'user')
         {

--- a/laravel/app/Http/routes.php
+++ b/laravel/app/Http/routes.php
@@ -74,7 +74,7 @@ Route::group(['middleware' => ['auth']], function()
 });
 
 // Routes available to both admins and judges
-Route::group(['middleware' => ['auth', 'role:admin|judge|observer']], function()
+Route::group(['middleware' => ['auth', 'role:admin|judge|kitten|observer']], function()
 {
     // Viewing questions
     Route::get('/questions', 'QuestionController@listQuestions');
@@ -129,14 +129,14 @@ Route::group(['middleware' => ['auth', 'role:admin']], function()
 
     // Update Scores
     Route::get('/recalcscores', 'ScoreController@recalcScores');
-    
+
     //Create Report
     Route::get('/reports/view', 'ReportsController@view');
-    Route::post('/report/generate', 'ReportsController@generateReport'); 
+    Route::post('/report/generate', 'ReportsController@generateReport');
 });
 
 // Routes only available to judges
-Route::group(['middleware' => ['auth', 'role:judge']], function()
+Route::group(['middleware' => ['auth', 'role:judge|kitten']], function()
 {
     // Scoring criteria
     Route::post('/score', 'ScoreController@scoreCriteria');

--- a/laravel/app/Listeners/QueueJudgeMessage.php
+++ b/laravel/app/Listeners/QueueJudgeMessage.php
@@ -53,7 +53,7 @@ class QueueJudgeMessage
         ];
 
         // Loop through all judges and queue a notification for them
-        $judges = User::whereIn('role', ['judge', 'observer'])->get();
+        $judges = User::whereIn('role', ['judge', 'kitten', 'observer'])->get();
 
         foreach($judges as $judge)
         {
@@ -84,7 +84,7 @@ class QueueJudgeMessage
         }
 
         // Loop through all judges and queue a notification for them
-        $judges = User::whereIn('role', ['judge', 'observer'])->get();
+        $judges = User::whereIn('role', ['judge', 'kitten', 'observer'])->get();
 
         foreach($judges as $judge)
         {

--- a/laravel/app/Providers/AuthServiceProvider.php
+++ b/laravel/app/Providers/AuthServiceProvider.php
@@ -70,6 +70,17 @@ class AuthServiceProvider extends ServiceProvider
             'create-feedback',
         ],
 
+        'kitten' =>
+        [
+            'view-users',
+            'view-questions',
+            'view-criteria',
+            'view-round',
+            'view-submitted-application',
+            'score-application',
+            'create-feedback',
+        ],
+
         'observer' =>
         [
             'view-submitted-application',

--- a/laravel/database/migrations/2025_01_13_010318_add_kitten_user_role.php
+++ b/laravel/database/migrations/2025_01_13_010318_add_kitten_user_role.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddKittenUserRole extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // NOTE: Modern versions of Laravel allow you to natively edit enumn columns, but in this version we have to use a raw SQL query
+        // This is incompatible with SQLite and only works for MySQL / MariaDB databases
+        DB::statement("ALTER TABLE `users` MODIFY COLUMN `role` ENUM('admin', 'applicant', 'judge', 'kitten', 'observer')");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement("ALTER TABLE `users` MODIFY COLUMN `role` ENUM('admin', 'applicant', 'judge', 'observer')");
+    }
+}

--- a/laravel/resources/views/pages/dashboard.blade.php
+++ b/laravel/resources/views/pages/dashboard.blade.php
@@ -57,7 +57,7 @@ $showrounds = $ongoing->merge($upcoming);
     @endif
 
     @if($applications->count())
-        @if(in_array(Auth::user()->role, ['judge', 'observer']))
+        @if(in_array(Auth::user()->role, ['judge', 'kitten', 'observer']))
             <h2>Applications Requiring Review</h2>
         @else
             <h2>Your Applications</h2>
@@ -127,7 +127,7 @@ $showrounds = $ongoing->merge($upcoming);
             <br>
         @endforeach
     @else
-        @if(in_array(Auth::user()->role, ['judge', 'observer']))
+        @if(in_array(Auth::user()->role, ['judge', 'kitten', 'observer']))
             <div class="general-alert alert alert-info" role="alert">
                 <b>Nothing Found</b> There are no applications which require review. Either none have been finalized yet, or all applications have already been judged.
             </div>

--- a/laravel/resources/views/pages/users/edit.blade.php
+++ b/laravel/resources/views/pages/users/edit.blade.php
@@ -17,6 +17,7 @@
             [
                 'applicant' => "Applicant",
                 'judge' => "Judge",
+                'kitten' => "Kitten",
                 'observer' => "Observer",
                 'admin' => "Admin",
             ],

--- a/laravel/resources/views/partials/header.blade.php
+++ b/laravel/resources/views/partials/header.blade.php
@@ -11,7 +11,7 @@
 
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
-                @if(Auth::check() && in_array(Auth::user()->role, ['admin', 'judge', 'observer']))
+                @if(Auth::check() && in_array(Auth::user()->role, ['admin', 'judge', 'kitten', 'observer']))
                     <li><a href="/applications">Applications</a></li>
                     <li><a href="/rounds">Rounds</a></li>
                     <li><a href="/users">Users</a></li>


### PR DESCRIPTION
This PR adds a new type of judge account called kittens. Kittens are allowed all the same permissions as judges except their scores are not included in the final calculation for application scores.

This is accomplished by:
- New migration to update the user role enum to support kitten option
- All references to judge permissions updated to include the new kitten option
- Application controller hardcoded to only allow kittens to abstain

There's already existing logic which causes a judge's scores to be ignored in calculations - the "abstain" status. Previously this status was used in situations where there was a conflict of interest or a judge was unavailable for some reason. This PR enforces that all applications which are judged by a kitten automatically get the "abstain" status, ensuring that their scores are not included in calculations. 